### PR TITLE
Add lock expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Include it in your hubot's package.json as a dependency, and it's external-scrip
 
 This section provides an example walkthrough of registering an application, adding environments for that application, and releasing a version of the application.
 
+# Setup
+
 ```
 # Add an application
 hubot application add foobar
@@ -22,17 +24,24 @@ hubot environment add staging to foobar
 
 hubot environment add production to foobar
 #=> environment production added to foobar
+```
 
+# Release
 
+```
 # Ask if you can release that application to that environment
 hubot can I release foobar to staging?
 #=> yes, foobar is releasable to staging
 
-
 # Release foobar/master to staging
 hubot release foobar/master to staging
-#=> user is now releasing hubot\/master to staging
+#=> user is now releasing hubot\/master to staging for 60 minutes
 
+hubot release foobar/master to staging for 30 minutes
+#=> user is now releasing hubot\/master to staging for 30 minutes
+
+hubot release foobar/master to staging for 2 hours
+#=> user is now releasing hubot\/master to staging for 120 minutes
 
 # Let other people release
 hubot done releasing foobar to staging

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "chai": "*",
     "hubot-test-helper": "akatz/hubot-test-helper",
     "mocha": "*",
-    "moment": "^2.9.0",
     "sinon": "*",
     "sinon-chai": "*",
     "supervisor": "*"

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "url": "https://github.com/shopkeep/hubot-atc/issues"
   },
   "dependencies": {
-    "coffee-script": "~1.6"
+    "coffee-script": "~1.6",
+    "moment": "^2.9.0"
   },
   "devDependencies": {
     "chai": "*",
     "hubot-test-helper": "akatz/hubot-test-helper",
     "mocha": "*",
+    "moment": "^2.9.0",
     "sinon": "*",
     "sinon-chai": "*",
     "supervisor": "*"

--- a/src/atc.coffee
+++ b/src/atc.coffee
@@ -41,6 +41,16 @@ module.exports = (robot) ->
   validateTarget = (msg, {applicationName, environmentName}) ->
     validateApplicationName(msg, applicationName) && validateEnvironmentName(msg, applicationName, environmentName)
 
+  validateExpires = (msg, {value, unit}) ->
+    return true unless value && unit
+
+    allowedUnits = ['minutes', 'hours', 'days']
+    return true if Number(value) > 0 && unit in allowedUnits
+
+    msg.reply "your given expiry was not recognised. Value must be greater than 0 and one of the following [#{allowedUnits.join(', ')}]"
+    false
+
+
   robot.respond /application add ([^\/\s]+)/i, (msg) ->
     applicationName = msg.match[1]
     applications = robot.brain.data.applications
@@ -94,6 +104,7 @@ module.exports = (robot) ->
 
     branch = msg.match[2] || "master"
     expires = { value: msg.match[4], unit: msg.match[5] }
+    return unless validateExpires(msg, expires)
 
     requester = msg.message.user.name
     locks = robot.brain.data.locks

--- a/src/locks/index.coffee
+++ b/src/locks/index.coffee
@@ -4,25 +4,25 @@ class Locks
   constructor: ->
     @locks = {}
 
-  keyFor: (applicationName, environmentName) ->
+  keyFor = (applicationName, environmentName) ->
     "#{applicationName}-#{environmentName}"
 
-  lockFor: (applicationName, environmentName) ->
-    key = @keyFor(applicationName, environmentName)
+  lockFor: ({applicationName, environmentName}) ->
+    key = keyFor(applicationName, environmentName)
     @locks[key]
 
-  add: (applicationName, environmentName, owner, branch) ->
-    key = @keyFor(applicationName, environmentName)
+  add: ({applicationName, environmentName}, owner, branch) ->
+    key = keyFor(applicationName, environmentName)
     lock = new Lock(applicationName, environmentName, owner, branch)
     @locks[key] = lock
     lock
 
-  remove: (applicationName, environmentName) ->
-    key = @keyFor(applicationName, environmentName)
+  remove: ({applicationName, environmentName}) ->
+    key = keyFor(applicationName, environmentName)
     @locks[key] = null
 
-  hasLock: (applicationName, environmentName) ->
-    key = @keyFor(applicationName, environmentName)
+  hasLock: ({applicationName, environmentName}) ->
+    key = keyFor(applicationName, environmentName)
     lock = @locks[key]
     lock?
 

--- a/src/locks/index.coffee
+++ b/src/locks/index.coffee
@@ -1,0 +1,29 @@
+Lock = require('./lock.coffee')
+
+class Locks
+  constructor: ->
+    @locks = {}
+
+  keyFor: (applicationName, environmentName) ->
+    "#{applicationName}-#{environmentName}"
+
+  lockFor: (applicationName, environmentName) ->
+    key = @keyFor(applicationName, environmentName)
+    @locks[key]
+
+  add: (applicationName, environmentName, owner, branch) ->
+    key = @keyFor(applicationName, environmentName)
+    lock = new Lock(applicationName, environmentName, owner, branch)
+    @locks[key] = lock
+    lock
+
+  remove: (applicationName, environmentName) ->
+    key = @keyFor(applicationName, environmentName)
+    @locks[key] = null
+
+  hasLock: (applicationName, environmentName) ->
+    key = @keyFor(applicationName, environmentName)
+    lock = @locks[key]
+    lock?
+
+module.exports = Locks

--- a/src/locks/lock.coffee
+++ b/src/locks/lock.coffee
@@ -1,3 +1,5 @@
+moment = require('moment')
+
 class Lock
   constructor: (applicationName, environmentName, owner, branch, expires) ->
     @applicationName = applicationName
@@ -9,7 +11,12 @@ class Lock
   expired: ->
     new Date() > @expires
 
+  remainingTime: ->
+    moment(@expires).diff(new Date(), 'minutes') + ' minutes'
+
   overview: ->
-    "#{@owner} is releasing #{@applicationName}/#{@branch} to #{@environmentName}"
+    "#{@owner} is releasing #{@applicationName}/#{@branch} " +
+    "to #{@environmentName} " +
+    "for #{@remainingTime()}"
 
 module.exports = Lock

--- a/src/locks/lock.coffee
+++ b/src/locks/lock.coffee
@@ -1,9 +1,13 @@
 class Lock
-  constructor: (applicationName, environmentName, owner, branch) ->
+  constructor: (applicationName, environmentName, owner, branch, expires) ->
     @applicationName = applicationName
     @environmentName = environmentName
     @owner = owner
     @branch = branch
+    @expires = expires
+
+  expired: ->
+    new Date() > @expires
 
   overview: ->
     "#{@owner} is releasing #{@applicationName}/#{@branch} to #{@environmentName}"

--- a/src/locks/lock.coffee
+++ b/src/locks/lock.coffee
@@ -1,0 +1,11 @@
+class Lock
+  constructor: (applicationName, environmentName, owner, branch) ->
+    @applicationName = applicationName
+    @environmentName = environmentName
+    @owner = owner
+    @branch = branch
+
+  overview: ->
+    "#{@owner} is releasing #{@applicationName}/#{@branch} to #{@environmentName}"
+
+module.exports = Lock

--- a/test/atc_test.coffee
+++ b/test/atc_test.coffee
@@ -223,7 +223,7 @@ describe 'hubot-atc', ->
 
             it 'allows you to release the lock', ->
               room.user.say "akatz", "hubot done releasing hubot to staging"
-              expect(lastMessage(room)).to.match /sorry, duncan is currently releasing hubot\/master to staging/
+              expect(lastMessage(room)).to.match /sorry, duncan is releasing hubot\/master to staging/
 
       context "without an environment", ->
         beforeEach ->

--- a/test/atc_test.coffee
+++ b/test/atc_test.coffee
@@ -165,6 +165,17 @@ describe 'hubot-atc', ->
               room.user.say "akatz", "hubot release hubot to staging"
               expect(lastMessage(room)).to.match /^akatz is releasing hubot\/master to staging for 60 minutes/
 
+            context 'invalid expiry', ->
+              expected_error_message = /akatz your given expiry was not recognised. Value must be greater than 0 and one of the following \[minutes, hours, days\]/
+
+              it 'validates invalid units', ->
+                room.user.say "akatz", "hubot release hubot to staging for 0 hours"
+                expect(lastMessage(room)).to.match expected_error_message
+
+              it 'validates invalid units', ->
+                room.user.say "akatz", "hubot release hubot to staging for 15 invalid_units"
+                expect(lastMessage(room)).to.match expected_error_message
+
             it 'allows you to specify an expiry in minutes', ->
               room.user.say "akatz", "hubot release hubot to staging for 30 minutes"
               expect(lastMessage(room)).to.match /^akatz is releasing hubot\/master to staging for 30 minutes/


### PR DESCRIPTION
This PR adds support for allowing locks on environments to expire. 

This can now be done with the following command -

```
hubot release hubot to staging for 30 minutes
=> akatz is releasing hubot/master to staging for 30 minutes

hubot release hubot to staging for 120 seconds
=> akatz is releasing hubot/master to staging for 2 minutes
```

If no expiry is supplied, it will be defaulted to 60 minutes - an arbitrary time. This can be changed/configurable in the future.

```
hubot release hubot to staging
=> akatz is releasing hubot/master to staging for 60 minutes
```

It is not currently possible to extend a lock acquired for an environment as part of this PR.