### PR TITLE
Do not use previously persisted locks when loading

### DIFF
--- a/src/atc.coffee
+++ b/src/atc.coffee
@@ -22,7 +22,7 @@ module.exports = (robot) ->
   robot.brain.on 'loaded', ->
     robot.brain.data.applications ||= []
     robot.brain.data.environments ||= {}
-    robot.brain.data.locks ||= new Locks()
+    robot.brain.data.locks = new Locks()
 
   validateApplicationName = (msg, applicationName) ->
     currentApplications = robot.brain.data.applications


### PR DESCRIPTION
The serialized format of the `Lock` object changed in the previous release, which causes problems during serialization. To deal with this we will opt to not use previously persisted locks when loading. 

A full term solution would be to - 

- Introduce ATC namespace to stop key collisions with other plugins
- Add ATC version number within the brain's data 
- Add migration support, IE upgrading from version `x` to `y`

Note, the Robot helper used within the testing framework does not appear to currently support persistence across room creations. Therefore the below tests were not included within this PR. This can be investigated further under the work above if it is pursued.

```coffeescript
  describe 'loading', ->
    beforeEach ->
      @oldRoom = room

      @oldRoom.user.say "duncan", "hubot application add hubot"
      @oldRoom.user.say "duncan", "hubot environment add staging to hubot"
      @oldRoom.user.say "duncan", "hubot release hubot to staging"

    dataFor = (room) ->
      room.robot.brain.data

    describe 'applications', ->
      it 'maintains applications', ->
        newRoom = helper.createRoom()
        expect(dataFor(@oldRoom).applications).to.eql(dataFor(newRoom).applications)

    describe 'environments', ->
      it 'maintains applications', ->
        newRoom = helper.createRoom()
        expect(dataFor(@oldRoom).environments).to.eql(dataFor(newRoom).environments)

    describe 'locks', ->
      hasLock = (room) ->
        target = { applicationName: 'hubot', environmentName: 'staging' }
        dataFor(room).locks.hasLock(target)

      it 'does not maintain old locks', ->
        expect(hasLock(@oldRoom)).to.be.true

        newRoom = helper.createRoom()
        expect(hasLock(newRoom)).to.be.false
```