### PR TITLE
Remove release lock expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,7 @@ hubot can I release foobar to staging?
 
 # Release foobar/master to staging
 hubot release foobar/master to staging
-#=> user is now releasing hubot\/master to staging for 60 minutes
-
-hubot release foobar/master to staging for 30 minutes
-#=> user is now releasing hubot\/master to staging for 30 minutes
-
-hubot release foobar/master to staging for 2 hours
-#=> user is now releasing hubot\/master to staging for 120 minutes
+#=> user is now releasing hubot\/master to staging
 
 # Let other people release
 hubot done releasing foobar to staging

--- a/package-lock.json
+++ b/package-lock.json
@@ -1016,11 +1016,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-    },
     "morgan": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "url": "https://github.com/shopkeep/hubot-atc/issues"
   },
   "dependencies": {
-    "coffee-script": "~1.6",
-    "moment": "^2.9.0"
+    "coffee-script": "~1.6"
   },
   "devDependencies": {
     "chai": "^4.1.1",

--- a/src/locks/index.coffee
+++ b/src/locks/index.coffee
@@ -1,17 +1,8 @@
 Lock = require('./lock.coffee')
-moment = require('moment')
 
 class Locks
   keyFor = (applicationName, environmentName) ->
     "#{applicationName}-#{environmentName}"
-
-  defaultExpires = ->
-    moment().add(60, 'minutes').toDate()
-
-  expiryFor = (expires) ->
-    return defaultExpires() unless expires.value && expires.unit
-
-    moment().add(expires.value, expires.unit)
 
   constructor: ->
     @locks = {}
@@ -19,17 +10,11 @@ class Locks
   lockFor: ({applicationName, environmentName}) ->
     key = keyFor(applicationName, environmentName)
     lock = @locks[key]
+    lock
 
-    if lock?.expired()
-      @remove({ applicationName: applicationName, environmentName: environmentName})
-      null
-    else
-      lock
-
-  add: ({applicationName, environmentName}, owner, branch, expires) ->
+  add: ({applicationName, environmentName}, owner, branch) ->
     key = keyFor(applicationName, environmentName)
-    expiry = expiryFor(expires)
-    lock = new Lock(applicationName, environmentName, owner, branch, expiry)
+    lock = new Lock(applicationName, environmentName, owner, branch)
     @locks[key] = lock
 
     lock

--- a/src/locks/lock.coffee
+++ b/src/locks/lock.coffee
@@ -1,22 +1,12 @@
-moment = require('moment')
-
 class Lock
   constructor: (applicationName, environmentName, owner, branch, expires) ->
     @applicationName = applicationName
     @environmentName = environmentName
     @owner = owner
     @branch = branch
-    @expires = expires
-
-  expired: ->
-    new Date() > @expires
-
-  remainingTime: ->
-    moment(@expires).diff(new Date(), 'minutes') + ' minutes'
 
   overview: ->
     "#{@owner} is releasing #{@applicationName}/#{@branch} " +
-    "to #{@environmentName} " +
-    "for #{@remainingTime()}"
+    "to #{@environmentName}"
 
 module.exports = Lock


### PR DESCRIPTION
Removes the feature allowing users to specify the length of time the lock for an application release will be held for and the default if a value is not provided.

Removing this feature also means we can remove the dependency on `moment`.

*These commits are easier to review by enabling the whitespace flag by appending `?w=1` to the URL when viewing the files changed*