### PR TITLE
Add ability to list applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-atc",
   "description": "An air traffic controller that powers your releases",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "ShopKeep<developers@shopkeep.com>",
   "license": "MIT",
   "keywords": [

--- a/src/atc.coffee
+++ b/src/atc.coffee
@@ -41,6 +41,13 @@ module.exports = (robot) ->
   validateTarget = (msg, {applicationName, environmentName}) ->
     validateApplicationName(msg, applicationName) && validateEnvironmentName(msg, applicationName, environmentName)
 
+  robot.respond /application list/i, (msg) ->
+    applications = robot.brain.data.applications
+    if applications.length > 0
+      msg.reply "applications available: #{applications.sort().join(', ')}"
+    else
+      msg.reply "No applications exist"
+
   robot.respond /application add ([^\/\s]+)/i, (msg) ->
     applicationName = msg.match[1]
     applications = robot.brain.data.applications

--- a/src/atc.coffee
+++ b/src/atc.coffee
@@ -44,7 +44,8 @@ module.exports = (robot) ->
   robot.respond /application list/i, (msg) ->
     applications = robot.brain.data.applications
     if applications.length > 0
-      msg.reply "applications available: #{applications.sort().join(', ')}"
+      sorted_applications = applications.sort().join(', ')
+      msg.reply "applications available: #{sorted_applications}"
     else
       msg.reply "No applications exist"
 

--- a/test/atc_test.coffee
+++ b/test/atc_test.coffee
@@ -56,7 +56,10 @@ describe 'hubot-atc', ->
 
         it 'responds with the proper message', ->
           @room.user.say("duncan", "hubot application list").then =>
-            expect(lastMessage(@room)).to.match /applications available: bar, foo/
+            expect(@room.messages).to.eql [
+              ['duncan', 'hubot application list'],
+              ['hubot', '@duncan applications available: bar, foo']
+            ]
 
     describe "adding", ->
       context "when there are none", ->

--- a/test/atc_test.coffee
+++ b/test/atc_test.coffee
@@ -43,6 +43,21 @@ describe 'hubot-atc', ->
     room.robot.brain.data.locks = locks
 
   describe "applications", ->
+    describe "listing", ->
+      context "when there are none", ->
+        it 'responds with the proper message', ->
+          @room.user.say("duncan", "hubot application list").then =>
+            expect(lastMessage(@room)).to.match /No applications exist/
+
+      context "when there are already apps", ->
+        beforeEach ->
+          addApplication(@room, "foo")
+          addApplication(@room, "bar")
+
+        it 'responds with the proper message', ->
+          @room.user.say("duncan", "hubot application list").then =>
+            expect(lastMessage(@room)).to.match /applications available: bar, foo/
+
     describe "adding", ->
       context "when there are none", ->
         it 'adds the application', ->


### PR DESCRIPTION
Adds a command to allow a list of applications to be retrieved. `application list` will either return `Mo applications exist`, or an alphabetically sorted list of available applications (such as `applications available: bar, foo, wibble`).